### PR TITLE
Support for Yocto Rocko

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-scipy = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-scipy = "6"
 
 LAYERDEPENDS_meta-scipy = "core openembedded-layer meta-python"
-LAYERSERIES_COMPAT_meta-scipy = "warrior thud zeus dunfell"
+LAYERSERIES_COMPAT_meta-scipy = "warrior thud zeus dunfell rocko"

--- a/recipes-devtools/cmake/cmake-native/0001-FortranCInterface-Fix-broken-search-for-test-exe-whe.patch
+++ b/recipes-devtools/cmake/cmake-native/0001-FortranCInterface-Fix-broken-search-for-test-exe-whe.patch
@@ -1,37 +1,33 @@
-From 0fc7b9df1c3b6515395bf646deffb25e91cb415b Mon Sep 17 00:00:00 2001
-From: Brad King <brad.king@kitware.com>
-Date: Thu, 27 Feb 2020 11:04:20 -0500
-Subject: [PATCH] FortranCInterface: Fix broken search for test exe when
- cross-compiling
-
-Previously the `find_program` call we used to locate the test executable
-but that can be broken by `CMAKE_FIND_ROOT_PATH_MODE_PROGRAM`.  Instead
-teach the test project to write a file with the location of the
-executable it builds.  Load that file to get the exact location.
-
-Fixes: #20390
----
- Modules/FortranCInterface/CMakeLists.txt |  4 ++++
- Modules/FortranCInterface/Detect.cmake   | 10 ++--------
- 2 files changed, 6 insertions(+), 8 deletions(-)
-
-diff --git a/Modules/FortranCInterface/CMakeLists.txt b/Modules/FortranCInterface/CMakeLists.txt
-index e3b81d7..71bd3ad 100644
---- a/Modules/FortranCInterface/CMakeLists.txt
-+++ b/Modules/FortranCInterface/CMakeLists.txt
-@@ -102,3 +102,7 @@ set_property(TARGET symbols PROPERTY POSITION_INDEPENDENT_CODE 1)
+diff --color -ur a/Modules/FortranCInterface/CMakeLists.txt b/Modules/FortranCInterface/CMakeLists.txt
+--- a/Modules/FortranCInterface/CMakeLists.txt	2020-10-15 06:53:04.182950336 +0200
++++ b/Modules/FortranCInterface/CMakeLists.txt	2020-10-15 06:52:35.444931287 +0200
+@@ -101,3 +101,7 @@
  # Require symbols through Fortran.
  add_executable(FortranCInterface main.F call_sub.f ${call_mod})
- target_link_libraries(FortranCInterface PUBLIC symbols)
+ target_link_libraries(FortranCInterface symbols)
 +
 +file(GENERATE OUTPUT exe-$<CONFIG>.cmake CONTENT [[
 +set(FortranCInterface_EXE "$<TARGET_FILE:FortranCInterface>")
 +]])
-diff --git a/Modules/FortranCInterface/Detect.cmake b/Modules/FortranCInterface/Detect.cmake
-index 7789785..1431dd8 100644
---- a/Modules/FortranCInterface/Detect.cmake
-+++ b/Modules/FortranCInterface/Detect.cmake
-@@ -43,17 +43,11 @@ set(FortranCInterface_COMPILED ${FortranCInterface_COMPILED})
+diff --color -ur a/Modules/FortranCInterface/Detect.cmake b/Modules/FortranCInterface/Detect.cmake
+--- a/Modules/FortranCInterface/Detect.cmake	2020-10-15 06:53:04.187950339 +0200
++++ b/Modules/FortranCInterface/Detect.cmake	2020-10-15 07:09:07.000000000 +0200
+@@ -27,6 +27,7 @@
+ set(_result)
+ 
+ # Build a sample project which reports symbols.
++set(CMAKE_TRY_COMPILE_CONFIGURATION Release)
+ try_compile(FortranCInterface_COMPILED
+   ${FortranCInterface_BINARY_DIR}
+   ${FortranCInterface_SOURCE_DIR}
+@@ -35,22 +36,18 @@
+   CMAKE_FLAGS
+     "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}"
+     "-DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}"
++    "-DCMAKE_C_FLAGS_RELEASE:STRING=${CMAKE_C_FLAGS_RELEASE}"
++    "-DCMAKE_Fortran_FLAGS_RELEASE:STRING=${CMAKE_Fortran_FLAGS_RELEASE}"
+   OUTPUT_VARIABLE FortranCInterface_OUTPUT)
+ set(FortranCInterface_COMPILED ${FortranCInterface_COMPILED})
  unset(FortranCInterface_COMPILED CACHE)
  
  # Locate the sample project executable.
@@ -39,7 +35,7 @@ index 7789785..1431dd8 100644
  if(FortranCInterface_COMPILED)
 -  find_program(FortranCInterface_EXE
 -    NAMES FortranCInterface${CMAKE_EXECUTABLE_SUFFIX}
--    PATHS ${FortranCInterface_BINARY_DIR} ${FortranCInterface_BINARY_DIR}/Release
+-    PATHS ${FortranCInterface_BINARY_DIR} ${FortranCInterface_BINARY_DIR}/Debug
 -    NO_DEFAULT_PATH
 -    )
 -  set(FortranCInterface_EXE ${FortranCInterface_EXE})

--- a/recipes-devtools/gcc/libgfortran_%.bbappend
+++ b/recipes-devtools/gcc/libgfortran_%.bbappend
@@ -1,0 +1,25 @@
+# Fix for libgorteaan recipe bug https://bugzilla.yoctoproject.org/show_bug.cgi?id=12394
+# delivered to master under http://cgit.openembedded.org/openembedded-core/commit/?id=2c2f20a9756eccafac776e45e319af7666e6da96
+
+do_configure () {
+   for target in libbacktrace libgfortran
+   do
+       rm -rf ${B}/${TARGET_SYS}/$target/
+       mkdir -p ${B}/${TARGET_SYS}/$target/
+       cd ${B}/${TARGET_SYS}/$target/
+       chmod a+x ${S}/$target/configure
+       relpath=${@os.path.relpath("${S}", "${B}/${TARGET_SYS}")}
+       ../$relpath/$target/configure ${CONFIGUREOPTS} ${EXTRA_OECONF}
+       # Easiest way to stop bad RPATHs getting into the library since we have a
+       # broken libtool here
+       sed -i -e 's/hardcode_into_libs=yes/hardcode_into_libs=no/' ${B}/${TARGET_SYS}/$target/libtool
+   done
+}
+
+do_compile () {
+   for target in libbacktrace libgfortran
+   do
+       cd ${B}/${TARGET_SYS}/$target/
+       oe_runmake MULTIBUILDTOP=${B}/${TARGET_SYS}/$target/
+   done
+}

--- a/recipes-devtools/lapack/lapack_%.bbappend
+++ b/recipes-devtools/lapack/lapack_%.bbappend
@@ -1,1 +1,0 @@
-EXTRA_OECMAKE_append = " -DCBLAS=ON"

--- a/recipes-devtools/lapack/lapack_3.9.0.bb
+++ b/recipes-devtools/lapack/lapack_3.9.0.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Linear Algebra PACKage"
+URL = "http://www.netlib.org/lapack"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=930f8aa500a47c7dab0f8efb5a1c9a40"
+
+# Recipe needs FORTRAN support (copied from conf/local.conf.sample.extended)
+# Enabling FORTRAN
+# Note this is not officially supported and is just illustrated here to
+# show an example of how it can be done
+# You'll also need your fortran recipe to depend on libgfortran
+#FORTRAN_forcevariable = ",fortran"
+#RUNTIMETARGET_append_pn-gcc-runtime = " libquadmath"
+
+DEPENDS = "libgfortran"
+
+SRCREV = "6acc99d5f39130be7cec00fb835606042101a970"
+SRC_URI = "git://github.com/Reference-LAPACK/lapack.git;protocol=https"
+S = "${WORKDIR}/git"
+
+EXTRA_OECMAKE = " -DBUILD_SHARED_LIBS=ON -DCBLAS=ON"
+OECMAKE_GENERATOR = "Unix Makefiles"
+
+inherit cmake pkgconfig
+EXCLUDE_FROM_WORLD = "1"
+
+FILES_${PN} = "${libdir}/cmake/* ${libdir}/*"

--- a/recipes-devtools/python/python3-scipy/0001-Allow-passing-flags-via-FARCH-for-mach.patch
+++ b/recipes-devtools/python/python3-scipy/0001-Allow-passing-flags-via-FARCH-for-mach.patch
@@ -1,24 +1,7 @@
-From cf25bb74f5426cda8d195a5a7f4324853a630b86 Mon Sep 17 00:00:00 2001
-From: Erik Botö <erik.boto@gmail.com>
-Date: Fri, 17 Apr 2020 09:18:58 +0200
-Subject: [PATCH] Allow passing flags via FARCH for mach
-
-Enable passing options via FARCH, so that the flags for setting the
-correct floating point ABI is propagated properly to the fortran
-compiler.
-
-This fixes an issue were the mach lib would otherwise be built as
-soft-float, even though the target arch is hard-float.
----
- scipy/integrate/setup.py | 3 +--
- scipy/special/setup.py   | 3 +--
- 2 files changed, 2 insertions(+), 4 deletions(-)
-
-diff --git a/scipy/integrate/setup.py b/scipy/integrate/setup.py
-index b0b530b..859bcb6 100644
---- a/scipy/integrate/setup.py
-+++ b/scipy/integrate/setup.py
-@@ -30,8 +30,7 @@ def configuration(parent_package='',top_path=None):
+diff --color -ur a/scipy/integrate/setup.py b/scipy/integrate/setup.py
+--- a/scipy/integrate/setup.py	2019-07-18 01:15:44.000000000 +0200
++++ b/scipy/integrate/setup.py	2020-10-16 07:56:48.150288830 +0200
+@@ -30,8 +30,7 @@
      quadpack_test_src = [join('tests','_test_multivariate.c')]
      odeint_banded_test_src = [join('tests', 'banded5x5.f')]
  
@@ -28,11 +11,10 @@ index b0b530b..859bcb6 100644
      config.add_library('quadpack', sources=quadpack_src)
      config.add_library('lsoda', sources=lsoda_src)
      config.add_library('vode', sources=vode_src)
-diff --git a/scipy/special/setup.py b/scipy/special/setup.py
-index b4b9d0c..e6b3bb3 100644
---- a/scipy/special/setup.py
-+++ b/scipy/special/setup.py
-@@ -55,8 +55,7 @@ def configuration(parent_package='',top_path=None):
+diff --color -ur a/scipy/special/setup.py b/scipy/special/setup.py
+--- a/scipy/special/setup.py	2020-01-20 21:44:32.000000000 +0100
++++ b/scipy/special/setup.py	2020-10-16 07:55:35.333251058 +0200
+@@ -55,8 +55,7 @@
      amos_src = [join('amos','*.f')]
      cdf_src = [join('cdflib','*.f')]
      specfun_src = [join('specfun','*.f')]
@@ -42,3 +24,12 @@ index b4b9d0c..e6b3bb3 100644
      config.add_library('sc_amos',sources=amos_src)
      config.add_library('sc_cdf',sources=cdf_src)
      config.add_library('sc_specfun',sources=specfun_src)
+@@ -107,7 +106,7 @@
+ 
+     # Cython API
+     config.add_data_files('cython_special.pxd')
+-    
++
+     cython_special_src = ['cython_special.c', 'sf_error.c', '_logit.c.src',
+                           "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"]
+     cython_special_dep = (headers + ufuncs_src + ufuncs_cxx_src + amos_src

--- a/recipes-devtools/python/python3-scipy_1.2.3.bb
+++ b/recipes-devtools/python/python3-scipy_1.2.3.bb
@@ -1,14 +1,14 @@
 SUMMARY = "SciPy: Scientific Library for Python"
 HOMEPAGE = "https://www.scipy.org"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=eb7262aea2504e4c0dfd16f5079e14dd"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=be4a7946a904c1b639bcfe4da4f795b8"
 
-SRC_URI = "https://files.pythonhosted.org/packages/a7/5c/495190b8c7cc71977c3d3fafe788d99d43eeb4740ac56856095df6a23fbd/scipy-1.3.3.tar.gz \
+SRC_URI = "https://files.pythonhosted.org/packages/62/4f/7e95c5000c411164d5ca6f55ac54cda5d200a3b6719dafd215ee0bd61578/scipy-1.2.3.tar.gz \
            file://0001-Allow-passing-flags-via-FARCH-for-mach.patch \
            "
 
-SRC_URI[md5sum] = "b265efea6ce2f2c1e580cc66bfb8b117"
-SRC_URI[sha256sum] = "64bf4e8ae0db2d42b58477817f648d81e77f0b381d0ea4427385bba3f959380a"
+SRC_URI[md5sum] = "43b42a507472dfa1dff4c91d58a6543f"
+SRC_URI[sha256sum] = "ecbe6413ca90b8e19f8475bfa303ac001e81b04ec600d17fa7f816271f7cca57"
 
 S = "${WORKDIR}/scipy-${PV}"
 


### PR DESCRIPTION
* Fix libgfortran recipe by redefining do_configure and do_compile jobs
  https://bugzilla.yoctoproject.org/show_bug.cgi?id=12394
* Update cmake patch to work with version 3.8.2
* Add lapack recipe